### PR TITLE
Register command changes

### DIFF
--- a/TheNewBoston.py
+++ b/TheNewBoston.py
@@ -73,6 +73,8 @@ async def register(ctx, address=None):
 
 	if address == None:
 		await ctx.send(f"To register your address, use the command `>register [address]`. After this, you need to send 1 coin or more to `{bot_wallet}` and then using the command `>verify` to confirm your address.")
+	elif len(address) < 64:
+		await ctx.send("Please enter a valid address!")
 	else:
 		users = await sync_to_async(User.objects.filter)(DiscordID=ctx.author.id)
 		owned = await sync_to_async(User.objects.filter)(Address=address)
@@ -81,6 +83,8 @@ async def register(ctx, address=None):
 		for pending in address_holder:
 			if pending.address == address:
 				other = True
+			if pending.user_id == ctx.author.id:
+				address_holder.remove([i for i in address_holder if i.user_id == ctx.author.id ][0])
 
 		if any(users):
 			await ctx.send(f"You already have a registered address: `{users[0].Address}`")


### PR DESCRIPTION
Made 2 changes
1. People can use `register` again and change the address as long as they haven't verified. This is useful for people who accidentally sent the wrong address.
2. The address supplied to the `register` command has to be at least 64 characters long. This is to make sure people don't send invalid account numbers.